### PR TITLE
update xopenai 1.1.3 execute支持commit选项控制

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Change Log
 
+## [1.1.3] - 2025.05.27
+
+### Features
+
+```python
+import asyncio
+from asmysql import AsMysql
+
+async def main():
+    async with AsMysql() as mysql:
+        # execute method supports the commit parameter to control transaction submission, 
+        # automatically determined by default.
+        await mysql.client.execute('insert into test(name) values("test")', commit=False)
+
+asyncio.run(main())
+```
+
 ## [1.1.0] - 2025.02.12
 
 ### Features

--- a/CHANGELOG_zh.md
+++ b/CHANGELOG_zh.md
@@ -1,5 +1,21 @@
 # Change Log
 
+## [1.1.3] - 2025.05.27
+
+### Features
+
+```python
+import asyncio
+from asmysql import AsMysql
+
+async def main():
+    async with AsMysql() as mysql:
+        # execute方法支持commit参数，用于控制是否提交事务，默认自动判断。
+        await mysql.client.execute('insert into test(name) values("test")', commit=False)
+
+asyncio.run(main())
+```
+
 ## [1.1.0] - 2025.02.12
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "asmysql"
-version = "1.1.2"
+version = "1.1.3"
 description = "An Asynchronous MySQL Client Engine Using Aiomysql."
 license = "MIT"
 authors = ["vastxiao <vastxiao@gmail.com>"]


### PR DESCRIPTION
# Change Log

## [1.1.3] - 2025.05.27

### Features

```python
import asyncio
from asmysql import AsMysql

async def main():
    async with AsMysql() as mysql:
        # execute method supports the commit parameter to control transaction submission, 
        # automatically determined by default.
        await mysql.client.execute('insert into test(name) values("test")', commit=False)

asyncio.run(main())
```